### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@ Make designing on Sketch fun again by using these Drake photos and lyrics as ass
 
 
 ## Demo
-#####Installation
+##### Installation
 1. Download Zip and Extract it to a folder
 2. In Sketch app `Plugins > Manage Plugins...`
 3. In the Preferences window, click on the cog-wheel icon, and select `Show Plugins Folder` from the dropdown.
 4. Place the extracted folder directly to the Plugins folder (nesting might not work atm)
 
-#####Generating Pictures
+##### Generating Pictures
 - Create a shape
 - Select shape
 - Go to `Plugins > Drake-Generator > Drake Photos > Generate Drake Photos`
 
-#####Generating Lyrics
+##### Generating Lyrics
 - Create text
 - Select text
 - Go to `Plugins > Drake-Generator > Drake Lyrics > Text > Lyrics > Generate or Replace`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
